### PR TITLE
Fixed heading typo

### DIFF
--- a/docs/general/desktop/README.mdx
+++ b/docs/general/desktop/README.mdx
@@ -1,4 +1,4 @@
-# Työåpöytäohjelmat
+# Työpöytäohjelmat
 
 Työpöytäohjelmat ovat ohjelmia, jotka on tarkoitettu käytettäväksi tietokoneen työpöydällä. Tässä osiossa käsitellään erilaisia työpöytäohjelmia, joita voit hyödyntää Bittivirran palveluita käytettäessä.
 


### PR DESCRIPTION
Fixed typo within the heading. "Työåpöytäohjelmat" -> "Työpöytäohjelmat"